### PR TITLE
use different sql command separator

### DIFF
--- a/macro.go
+++ b/macro.go
@@ -56,7 +56,7 @@ func (m *Macro) Call(input map[string]interface{}) (interface{}, error) {
 			return err.Error(), err
 		}
 	} else {
-		out, err = m.execSQLQuery(strings.Split(strings.TrimSpace(m.Exec), "--"), input)
+		out, err = m.execSQLQuery(strings.Split(strings.TrimSpace(m.Exec), "--//--"), input)
 		if err != nil {
 			return err.Error(), err
 		}

--- a/macro.go
+++ b/macro.go
@@ -56,7 +56,7 @@ func (m *Macro) Call(input map[string]interface{}) (interface{}, error) {
 			return err.Error(), err
 		}
 	} else {
-		out, err = m.execSQLQuery(strings.Split(strings.TrimSpace(m.Exec), ";"), input)
+		out, err = m.execSQLQuery(strings.Split(strings.TrimSpace(m.Exec), "--"), input)
 		if err != nil {
 			return err.Error(), err
 		}


### PR DESCRIPTION
Current separator `;` causes problem when using `BEGIN TRANSACTION` or `CREATE TRIGGER`, example (using `sqlite3`):
```hcl
_boot {
    exec = <<SQL

        CREATE TABLE IF NOT EXISTS "Bucket" (
            "name" VARCHAR(255) NOT NULL PRIMARY KEY,
            "dir" VARCHAR(255) UNIQUE NOT NULL,
            "createdAt" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
        );
        CREATE TRIGGER IF NOT EXISTS "trig1" 
        BEFORE INSERT ON "Bucket"
        BEGIN
            SELECT RAISE(ABORT, 'Dir can not be /dev') WHERE NEW.dir like '/dev%';
        END;
   SQL
}
```
It generates sql commands like these:
```
CREATE TRIGGER IF NOT EXISTS "trig1" 
        BEFORE INSERT ON "Bucket"
        BEGIN
            SELECT RAISE(ABORT, 'Dir can not be /dev') WHERE NEW.dir like '/dev%';
```
and
```
END;
```
