### PR TITLE
fix: correct Faild→Failed typo in cron error message (manager.go)

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -66,7 +66,7 @@ func NewManager(configpath string) (*Manager, error) {
 						_, err := manager.cron.AddFunc(v.Cron, func() {
 							fmt.Println(color.YellowString("=> Executing cron " + v.name))
 							if _, err := v.Call(map[string]interface{}{}); err != nil {
-								fmt.Println(color.RedString("=> Faild executing cron " + v.name + " due to an error: " + err.Error()))
+								fmt.Println(color.RedString("=> Failed executing cron " + v.name + " due to an error: " + err.Error()))
 							} else {
 								fmt.Println(color.GreenString("=> Executing cron " + v.name + " succeeded!"))
 							}


### PR DESCRIPTION
## Summary
Fix `Faild` → `Failed` typo in user-facing fmt.Println error message for cron job execution failures.

## Changes
- Line 69: `=> Faild executing cron ...` → `=> Failed executing cron ...`

The error message is displayed via color.RedString(...) making it prominently visible to users when a cron job fails.

## Testing
```bash
go build ./...
```